### PR TITLE
refactor(bundler): refactor extraction regexes

### DIFF
--- a/lib/modules/manager/bundler/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/bundler/__snapshots__/extract.spec.ts.snap
@@ -542,12 +542,15 @@ exports[`modules/manager/bundler/extract extractPackageFile() parse mastodon Gem
       },
     },
     {
+      "currentDigest": "54b17ba8c7d8d20a16dfc65d1775241833219cf2",
       "currentValue": "'~> 0.6'",
-      "datasource": "rubygems",
+      "datasource": "git-refs",
       "depName": "http_parser.rb",
       "managerData": {
         "lineNumber": 57,
       },
+      "packageName": "https://github.com/tmm1/http_parser.rb",
+      "sourceUrl": "https://github.com/tmm1/http_parser.rb",
     },
     {
       "currentValue": "'~> 1.3'",
@@ -1606,7 +1609,7 @@ exports[`modules/manager/bundler/extract extractPackageFile() parses rails Gemfi
       },
     },
     {
-      "currentValue": "">= 3.0.5", "< 3.2"",
+      "currentValue": "">= 3.0.5"",
       "datasource": "rubygems",
       "depName": "listen",
       "lockedVersion": "3.1.5",

--- a/lib/modules/manager/bundler/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/bundler/__snapshots__/extract.spec.ts.snap
@@ -1609,7 +1609,7 @@ exports[`modules/manager/bundler/extract extractPackageFile() parses rails Gemfi
       },
     },
     {
-      "currentValue": "">= 3.0.5"",
+      "currentValue": "">= 3.0.5", "< 3.2"",
       "datasource": "rubygems",
       "depName": "listen",
       "lockedVersion": "3.1.5",

--- a/lib/modules/manager/bundler/extract.spec.ts
+++ b/lib/modules/manager/bundler/extract.spec.ts
@@ -171,14 +171,21 @@ describe('modules/manager/bundler/extract', () => {
   it('parses inline source in Gemfile', async () => {
     const sourceInlineGemfile = codeBlock`
       baz = 'https://gems.baz.com'
+      gem 'inline_gem'
       gem "inline_source_gem", source: 'https://gems.foo.com'
       gem 'inline_source_gem_with_version', "~> 1", source: 'https://gems.bar.com'
       gem 'inline_source_gem_with_variable_source', source: baz
+      gem "inline_source_gem_with_require_after", source: 'https://gems.foo.com', require: %w[inline_source_gem]
+      gem "inline_source_gem_with_require_before", require: %w[inline_source_gem], source: 'https://gems.foo.com'
+      gem "inline_source_gem_with_group_before", group: :production, source: 'https://gems.foo.com'
       `;
     fs.readLocalFile.mockResolvedValueOnce(sourceInlineGemfile);
     const res = await extractPackageFile(sourceInlineGemfile, 'Gemfile');
     expect(res).toMatchObject({
       deps: [
+        {
+          depName: 'inline_gem',
+        },
         {
           depName: 'inline_source_gem',
           registryUrls: ['https://gems.foo.com'],
@@ -191,6 +198,18 @@ describe('modules/manager/bundler/extract', () => {
         {
           depName: 'inline_source_gem_with_variable_source',
           registryUrls: ['https://gems.baz.com'],
+        },
+        {
+          depName: 'inline_source_gem_with_require_after',
+          registryUrls: ['https://gems.foo.com'],
+        },
+        {
+          depName: 'inline_source_gem_with_require_before',
+          registryUrls: ['https://gems.foo.com'],
+        },
+        {
+          depName: 'inline_source_gem_with_group_before',
+          registryUrls: ['https://gems.foo.com'],
         },
       ],
     });

--- a/lib/modules/manager/bundler/extract.spec.ts
+++ b/lib/modules/manager/bundler/extract.spec.ts
@@ -250,4 +250,29 @@ describe('modules/manager/bundler/extract', () => {
       ],
     });
   });
+
+  it('parses multiple current values Gemfile', async () => {
+    const multipleValuesGemfile = codeBlock`
+      gem 'gem_without_values'
+      gem 'gem_with_one_value', ">= 3.0.5"
+      gem 'gem_with_multiple_values', ">= 3.0.5", "< 3.2"
+    `;
+    fs.readLocalFile.mockResolvedValueOnce(multipleValuesGemfile);
+    const res = await extractPackageFile(multipleValuesGemfile, 'Gemfile');
+    expect(res).toMatchObject({
+      deps: [
+        {
+          depName: 'gem_without_values',
+        },
+        {
+          depName: 'gem_with_one_value',
+          currentValue: '">= 3.0.5"',
+        },
+        {
+          depName: 'gem_with_multiple_values',
+          currentValue: '">= 3.0.5", "< 3.2"',
+        },
+      ],
+    });
+  });
 });

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -17,7 +17,7 @@ const variableMatchRegex = regEx(
   `^(?<key>\\w+)\\s*=\\s*['"](?<value>[^'"]+)['"]`,
 );
 const gemMatchRegex = regEx(
-  `^\\s*gem\\s+(['"])(?<depName>[^'"]+)(['"])(\\s*,\\s*(?<currentValue>['"][^'"]+['"]))?`,
+  `^\\s*gem\\s+(['"])(?<depName>[^'"]+)(['"])(\\s*,\\s*(?<currentValue>(['"])[^'"]+['"](\\s*,\\s*['"][^'"]+['"])?))?`,
 );
 const sourceMatchRegex = regEx(
   `source:\\s*(['"](?<registryUrl>[^'"]+)['"]|(?<sourceName>[^'"]+))?`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Break the line regex into mutliple one. Instead of capture all the line at once, we ensure it's a `gem` line, then apply other regexes sequentially. A few benefits:

- Readability
- Support randomly ordered arguments (e.g. `gem 'foo', source: baz, require: 'bar'` and `gem 'foo', source: baz, require: 'bar'` are now parsed the same way

Current tests are still passing.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
